### PR TITLE
Wrap DSB with qp2p

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -3,9 +3,9 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 
 use ed25519::{PublicKey, Signature};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Eq, Clone, Copy, Serialize)]
+#[derive(Eq, Clone, Copy, Serialize, Deserialize)]
 pub struct Actor(pub PublicKey);
 
 impl PartialEq for Actor {
@@ -45,7 +45,7 @@ impl fmt::Debug for Actor {
     }
 }
 
-#[derive(Eq, Clone, Copy, Serialize)]
+#[derive(Eq, Clone, Copy, Serialize, Deserialize)]
 pub struct Sig(pub Signature);
 
 impl PartialEq for Sig {

--- a/src/orswot/mod.rs
+++ b/src/orswot/mod.rs
@@ -1,2 +1,4 @@
 pub mod bft_orswot;
 pub mod bft_orswot_net;
+
+pub use bft_orswot::BFTOrswot;

--- a/src/qp2p_proc.rs
+++ b/src/qp2p_proc.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 
-use cmdr::*; // cli repl
+use cmdr::*;
 
 use qp2p::{self, Config, Endpoint, QuicP2p};
 use std::{
@@ -76,10 +76,10 @@ impl Repl {
         match args {
             [ip_port] => match ip_port.parse::<SocketAddr>() {
                 Ok(addr) => {
-                    println!("[CLI/REPL] parsed addr {:?}", addr);
+                    println!("[REPL] parsed addr {:?}", addr);
                     self.network_tx.try_send(RouterCmd::SayHello(addr)).unwrap();
                 }
-                Err(e) => println!("[CLI/REPL] bad addr {:?}", e),
+                Err(e) => println!("[REPL] bad addr {:?}", e),
             },
             _ => println!("help: peer <ip>:<port>"),
         };
@@ -97,7 +97,7 @@ impl Repl {
                             .expect("Failed to queue packet");
                     }
                 }
-                Err(_) => println!("[CLI/REPL] bad arg: '{}'", arg),
+                Err(_) => println!("[REPL] bad arg: '{}'", arg),
             },
             _ => println!("help: add <v>"),
         }
@@ -115,7 +115,7 @@ impl Repl {
                             .expect("Failed to queue packet");
                     }
                 }
-                Err(_) => println!("[CLI/REPL] bad arg: '{}'", arg),
+                Err(_) => println!("[REPL] bad arg: '{}'", arg),
             },
             _ => println!("help: remove <v>"),
         }
@@ -198,7 +198,7 @@ impl Router {
     async fn deliver_packet(&self, packet: Packet) {
         if let Some((peer, addr)) = self.peers.get(&packet.dest) {
             println!(
-                "[CLI/RTR] delivering packet to {:?} at addr {:?}",
+                "[P2P] delivering packet to {:?} at addr {:?}",
                 packet.dest, addr
             );
             let msg = bincode::serialize(&NetworkMsg::Packet(packet)).unwrap();
@@ -207,14 +207,14 @@ impl Router {
             conn.close()
         } else {
             println!(
-                "[CLI/RTR] we don't have a peer matching the destination for packet {:?}",
+                "[P2P] we don't have a peer matching the destination for packet {:?}",
                 packet
             );
         }
     }
 
     async fn apply(&mut self, cmd: RouterCmd) {
-        println!("[CLI/RTR] router cmd {:?}", cmd);
+        println!("[P2P] router cmd {:?}", cmd);
         match cmd {
             RouterCmd::SayHello(addr) => {
                 let peer = self.new_endpoint();
@@ -253,7 +253,7 @@ impl Router {
 }
 
 async fn listen_for_ops(endpoint: Endpoint, mut router_tx: mpsc::Sender<RouterCmd>) {
-    println!("[CLI] listening on {:?}", endpoint.our_addr());
+    println!("[P2P] listening on {:?}", endpoint.our_addr());
 
     router_tx
         .send(RouterCmd::SayHello(endpoint.our_addr().unwrap()))
@@ -278,7 +278,7 @@ async fn listen_for_ops(endpoint: Endpoint, mut router_tx: mpsc::Sender<RouterCm
                 }
             }
         }
-        Err(e) => println!("[CLI/ERROR] failed to start listening: {:?}", e),
+        Err(e) => println!("[P2P/ERROR] failed to start listening: {:?}", e),
     }
 }
 


### PR DESCRIPTION
Changes:
* qp2p peering protocol is: `HelloMyNameIs(my_actor, my_addr), HelloMyNameIs(their_actor, their_addr), HelloMyNameIs(my_actor, my_addr)`

* we replace the `HashSet` with `SecureBroadcastProc<BFTOrswot<u64>>`
* membership requests are not yet supported, but we can operate on our own orswot using the DSB machinary:

Sample run, adding `2` to our orswot:
```
$ cargo run --bin qp2p_proc
[CLI] listening on Ok(127.0.0.1:59041)
[CLI/RTR] router cmd SayHello(127.0.0.1:59041)
[CLI/RTR] router cmd AddPeer(i:e72f.., 127.0.0.1:59041)
[CLI/RTR] router cmd AddPeer(i:e72f.., 127.0.0.1:59041)

> add 2
[DSB] i:e72f.. initiating bft for msg Msg { op: AlgoOp(Add { dot: Dot { actor: i:e72f.., counter: 1 }, members: [2] }), dot: Dot { actor: i:e72f.., counter: 1 } }
[DSB] broadcasting i:e72f..->{i:e72f..}
[CLI/RTR] router cmd Deliver(Packet { source: i:e72f.., dest: i:e72f.., payload: RequestValidation { msg: Msg { op: AlgoOp(Add { dot: Dot { actor: i:e72f.., counter: 1 }, members: [2] }), dot: Dot { actor: i:e72f.., counter: 1 } } }, sig: sig:7aa3.. })
[CLI/RTR] delivering packet to i:e72f.. at addr 127.0.0.1:59041
[CLI/RTR] router cmd Apply(Packet { source: i:e72f.., dest: i:e72f.., payload: RequestValidation { msg: Msg { op: AlgoOp(Add { dot: Dot { actor: i:e72f.., counter: 1 }, members: [2] }), dot: Dot { actor: i:e72f.., counter: 1 } } }, sig: sig:7aa3.. })
[DSB] handling packet from i:e72f..->i:e72f..
[DSB] request for validation
[CLI/RTR] delivering packet to i:e72f.. at addr 127.0.0.1:59041
[CLI/RTR] router cmd Apply(Packet { source: i:e72f.., dest: i:e72f.., payload: SignedValidated { msg: Msg { op: AlgoOp(Add { dot: Dot { actor: i:e72f.., counter: 1 }, members: [2] }), dot: Dot { actor: i:e72f.., counter: 1 } }, sig: sig:587e.. }, sig: sig:ecf6.. })
[DSB] handling packet from i:e72f..->i:e72f..
[DSB] signed validated
[DSB] we have quorum over msg, sending proof to network
[DSB] broadcasting i:e72f..->{i:e72f..}
[CLI/RTR] delivering packet to i:e72f.. at addr 127.0.0.1:59041
[CLI/RTR] router cmd Apply(Packet { source: i:e72f.., dest: i:e72f.., payload: ProofOfAgreement { msg: Msg { op: AlgoOp(Add { dot: Dot { actor: i:e72f.., counter: 1 }, members: [2] }), dot: Dot { actor: i:e72f.., counter: 1 } }, proof: {i:e72f..: sig:587e..} }, sig: sig:43a1.. })
[DSB] handling packet from i:e72f..->i:e72f..
[DSB] proof of agreement

> read
{2}

>
```