### PR TITLE
Join Network Requests

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -35,7 +35,7 @@ impl Ord for Actor {
 impl fmt::Display for Actor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let bytes = self.0.as_bytes();
-        write!(f, "i:{}..", hex::encode(&bytes[..2]))
+        write!(f, "i:{}", hex::encode(&bytes[..2]))
     }
 }
 
@@ -63,7 +63,7 @@ impl Hash for Sig {
 impl fmt::Display for Sig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let bytes = self.0.to_bytes();
-        write!(f, "sig:{}..", hex::encode(&bytes[..2]))
+        write!(f, "sig:{}", hex::encode(&bytes[..2]))
     }
 }
 

--- a/src/deterministic_secure_broadcast.rs
+++ b/src/deterministic_secure_broadcast.rs
@@ -124,6 +124,10 @@ impl<A: SecureBroadcastAlgorithm> SecureBroadcastProc<A> {
         self.peers.clone()
     }
 
+    pub fn trust_peer(&mut self, peer: Actor) {
+        self.peers.insert(peer);
+    }
+
     pub fn request_membership(&self) -> Vec<Packet<A::Op>> {
         self.exec_bft_op(BFTOp::MembershipNewPeer(self.actor()))
     }

--- a/src/deterministic_secure_broadcast.rs
+++ b/src/deterministic_secure_broadcast.rs
@@ -83,22 +83,11 @@ impl<A: SecureBroadcastAlgorithm> SecureBroadcastProc<A> {
         let keypair = Keypair::generate(&mut OsRng);
         let actor = Actor(keypair.public);
 
-        let peers = if known_peers.is_empty() {
-            // This is the genesis proc. It must be treated as a special case.
-            //
-            // Under normal conditions when a proc joins an existing network, it will only
-            // add itself to it's own peer set once it receives confirmation from the rest
-            // of the network that it has been accepted as a member of the network.
-            std::iter::once(actor).collect()
-        } else {
-            known_peers
-        };
-
         Self {
             keypair,
             pending_proof: HashMap::new(),
             algo: A::new(actor),
-            peers,
+            peers: known_peers,
             delivered: VClock::new(),
             received: VClock::new(),
         }

--- a/src/deterministic_secure_broadcast.rs
+++ b/src/deterministic_secure_broadcast.rs
@@ -342,7 +342,7 @@ impl<A: SecureBroadcastAlgorithm> SecureBroadcastProc<A> {
     }
 
     fn quorum(&self, n: usize) -> bool {
-        n * 3 >= self.peers.len() * 2
+        n * 3 > self.peers.len() * 2
     }
 
     fn broadcast(&self, payload: &Payload<A::Op>) -> Vec<Packet<A::Op>> {

--- a/src/deterministic_secure_broadcast.rs
+++ b/src/deterministic_secure_broadcast.rs
@@ -319,7 +319,13 @@ impl<A: SecureBroadcastAlgorithm> SecureBroadcastProc<A> {
     fn validate_bft_op(&self, from: &Actor, bft_op: &BFTOp<A::Op>) -> bool {
         let validation_tests = match bft_op {
             BFTOp::MembershipNewPeer(_id) => vec![], // In a proper deployment, add some validations to resist Sybil attacks
-            BFTOp::AlgoOp(op) => vec![(self.algo.validate(&from, &op), "failed algo validation")],
+            BFTOp::AlgoOp(op) => vec![
+                (
+                    self.peers.contains(&from),
+                    "source is not a member of the network",
+                ),
+                (self.algo.validate(&from, &op), "failed algo validation"),
+            ],
         };
 
         validation_tests

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 
 use crate::actor::Actor;
 use crate::deterministic_secure_broadcast::{Packet, SecureBroadcastProc};
@@ -20,7 +20,7 @@ impl<A: SecureBroadcastAlgorithm> Net<A> {
 
     /// The largest set of procs who mutually see each other as peers
     /// are considered to be the network members.
-    pub fn members(&self) -> HashSet<Actor> {
+    pub fn members(&self) -> BTreeSet<Actor> {
         self.procs
             .iter()
             .map(|proc| {
@@ -29,14 +29,14 @@ impl<A: SecureBroadcastAlgorithm> Net<A> {
                     .flat_map(|peer| self.proc_from_actor(peer))
                     .filter(|peer_proc| peer_proc.peers().contains(&proc.actor()))
                     .map(|peer_proc| peer_proc.actor())
-                    .collect::<HashSet<_>>()
+                    .collect::<BTreeSet<_>>()
             })
             .max_by_key(|members| members.len())
             .unwrap_or_default()
     }
 
     /// Fetch the actors for each process in the network
-    pub fn actors(&self) -> HashSet<Actor> {
+    pub fn actors(&self) -> BTreeSet<Actor> {
         self.procs.iter().map(|p| p.actor()).collect()
     }
 
@@ -87,7 +87,7 @@ impl<A: SecureBroadcastAlgorithm> Net<A> {
         // TODO: this should be done through a message passing interface.
 
         // For each proc, collect the procs who considers this proc it's peer.
-        let mut peer_reverse_index: HashMap<Actor, HashSet<Actor>> = HashMap::new();
+        let mut peer_reverse_index: HashMap<Actor, BTreeSet<Actor>> = HashMap::new();
 
         for proc in self.procs.iter() {
             for peer in proc.peers() {

--- a/src/qp2p_proc.rs
+++ b/src/qp2p_proc.rs
@@ -6,7 +6,7 @@ use cmdr::*;
 
 use qp2p::{self, Config, Endpoint, QuicP2p};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     net::{IpAddr, Ipv4Addr, SocketAddr},
 };
 

--- a/src/qp2p_proc.rs
+++ b/src/qp2p_proc.rs
@@ -49,6 +49,10 @@ impl SharedDSB {
         self.dsb.lock().unwrap().trust_peer(peer);
     }
 
+    fn request_membership(&mut self) -> Vec<Packet> {
+        self.dsb.lock().unwrap().request_membership()
+    }
+
     fn exec_algo_op(
         &self,
         f: impl FnOnce(&State) -> Option<<State as SecureBroadcastAlgorithm>::Op>,
@@ -113,6 +117,21 @@ impl Repl {
                     .unwrap();
             }
             _ => println!("help: trust id:8sdkgalsd"),
+        };
+        Ok(Action::Done)
+    }
+
+    #[cmd]
+    fn join(&mut self, args: &[String]) -> CommandResult {
+        match args {
+            [] => {
+                for packet in self.state.request_membership() {
+                    self.network_tx
+                        .try_send(RouterCmd::Deliver(packet))
+                        .expect("Failed to queue packet");
+                }
+            }
+            _ => println!("help: join takes no arguments"),
         };
         Ok(Action::Done)
     }

--- a/src/qp2p_proc.rs
+++ b/src/qp2p_proc.rs
@@ -273,7 +273,7 @@ impl Router {
     }
 }
 
-async fn listen_for_ops(endpoint: Endpoint, mut router_tx: mpsc::Sender<RouterCmd>) {
+async fn listen_for_network_msgs(endpoint: Endpoint, mut router_tx: mpsc::Sender<RouterCmd>) {
     println!("[P2P] listening on {:?}", endpoint.our_addr());
 
     router_tx
@@ -309,7 +309,7 @@ async fn main() {
     let (router, endpoint) = Router::new(state.clone());
     let (router_tx, router_rx) = mpsc::channel(100);
 
-    tokio::spawn(listen_for_ops(endpoint, router_tx.clone()));
+    tokio::spawn(listen_for_network_msgs(endpoint, router_tx.clone()));
     tokio::spawn(router.listen_for_cmds(router_rx));
     cmd_loop(&mut Repl::new(state, router_tx)).expect("Failure in REPL");
 }


### PR DESCRIPTION
Three new commands added to the REPL:

1. `peers`: Lists the current `qp2p` peers, peers who are also voting `DSB` peers will be marked as `(voting)`:
```
> peers
i:ac07c19f@127.0.0.1:39224
i:6c0e3796@127.0.0.1:39547	(voting)

peer format:
--pubkey--@----ip:port----
```

2. `trust i:ac07`: Locally trust the actor with the matching id, promoting it to a voting peer
```
> trust i:ac07
> peers
i:ac07c19f@127.0.0.1:39224	(voting)
i:6c0e3796@127.0.0.1:39547	(voting)
```

3. `join`: Request the network to accept you as a voting member
```
> peers
i:ac07c19f@127.0.0.1:39224	# < me
i:6c0e3796@127.0.0.1:39547	(voting)
> join
.... DSB protocol logs ...
> peers
i:ac07c19f@127.0.0.1:39224	(voting)
i:6c0e3796@127.0.0.1:39547	(voting)
```

#### Changes to DSB:
1. we no longer assume you are a voting member if you have no bootstrap peers
2. switch to BTreeXXX from HashXXX to ensure deterministic encodings across processes.
3. strictly greater than 2/3rds for quorum (we were >= 2/3rds)
4. rejet `AlgoOps` from peers who are not voting members