### PR TITLE
Fix Issues with Joining

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ path = "src/qp2p_proc.rs"
 crdts = "4.0.0"
 ed25519 = { version = "1.0.0", package = "ed25519-dalek", features = ["serde"] }
 rand = "0.7.3"
-sha2 = "0.8.1"
 serde = "1.0.106"
 bincode = "1.2.1"
 hex = "0.4.2"

--- a/src/bank/bft_bank_net.rs
+++ b/src/bank/bft_bank_net.rs
@@ -58,12 +58,13 @@ mod tests {
         for balance in balance_iter {
             let actor = net.initialize_proc();
             net.on_proc_mut(&actor, |p| p.trust_peer(genesis_actor));
-            net.run_packets_to_completion(net.on_proc(&actor, |p| p.request_membership()).unwrap());
             net.anti_entropy();
+            net.run_packets_to_completion(net.on_proc(&actor, |p| p.request_membership()).unwrap());
+            assert!(net.members_are_in_agreement());
+
             // TODO: add a test where the initiating actor is different from hte owner account
             net.run_packets_to_completion(net.open_account(actor, actor, balance).unwrap());
         }
-
         assert!(net.members_are_in_agreement());
     }
 

--- a/src/orswot/bft_orswot_net.rs
+++ b/src/orswot/bft_orswot_net.rs
@@ -26,8 +26,8 @@ mod tests {
         for _ in 0..(n_procs - 1) {
             let actor = net.initialize_proc();
             net.on_proc_mut(&actor, |p| p.trust_peer(genesis_actor));
-            net.run_packets_to_completion(net.on_proc(&actor, |p| p.request_membership()).unwrap());
             net.anti_entropy();
+            net.run_packets_to_completion(net.on_proc(&actor, |p| p.request_membership()).unwrap());
         }
 
         assert_eq!(net.members(), net.actors());

--- a/src/qp2p_proc.rs
+++ b/src/qp2p_proc.rs
@@ -33,7 +33,7 @@ struct SharedDSB {
 impl SharedDSB {
     fn new() -> Self {
         Self {
-            dsb: Arc::new(Mutex::new(DSB::new(Default::default()))),
+            dsb: Arc::new(Mutex::new(DSB::new())),
         }
     }
 


### PR DESCRIPTION
Changes:
* DSB no longer takes a set of known peers, clients must manually call `::trust_peer(...)` to mark an actor as a voting member
* When requesting to join a network, we no longer add our selves to the peer set when we detect quorum, instead we add ourselves to the recipients of the `proof` broadcast so that we can re-use the existing code to mutate our peer set.
* Get tests passing again